### PR TITLE
feat(release): enable generation of release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,5 +78,6 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tagversion.outputs.current-version }}
+          generate_release_notes: true
           files: |
             firmware/*


### PR DESCRIPTION
Adds the `generate_release_notes` option to the GitHub Actions 
workflow for releases.