### PR TITLE
chore: remove tag_name from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,6 @@ jobs:
       
       - uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tagversion.outputs.current-version }}
           generate_release_notes: true
           files: |
             firmware/*


### PR DESCRIPTION
Removes the tag_name input from the GitHub Actions release 
workflow.