### PR TITLE
fix(heliostat): clean up socket event listener on destroy

### DIFF
--- a/interface/src/routes/heliostat/Heliostat.svelte
+++ b/interface/src/routes/heliostat/Heliostat.svelte
@@ -25,6 +25,10 @@
 		});
 	});
 
+	onDestroy(() => {
+		socket.off(heliostatControllerStateEvent);
+	});
+
 </script>
 
 {#if heliostatControllerState}


### PR DESCRIPTION
Add an `onDestroy` lifecycle method to remove the socket event listener 
for `heliostatControllerStateEvent`. This prevents potential memory leaks 
and ensures that the component cleans up properly when it is no longer 
in use.